### PR TITLE
refactor: 추천페이지 수정

### DIFF
--- a/src/components/recommend/BookRecommendGuide.tsx
+++ b/src/components/recommend/BookRecommendGuide.tsx
@@ -24,7 +24,7 @@ const BookRecommendGuide = () => {
             어떤 책을 추천해드릴까요?
           </h1>
           <h3 className='text-[#707070] text-center pb-5 text-clampSm'>
-            안녕하세요! 똑똑한 독서 메이트 00 입니다. <br /> 나에게 맞는 책을
+            안녕하세요! 똑똑한 독서 메이트입니다. <br /> 나에게 맞는 책을
             추천해드릴게요!
           </h3>
           <div className='flex justify-center'>
@@ -38,7 +38,7 @@ const BookRecommendGuide = () => {
         </section>
         <div className='w-full'>
           <button
-            onClick={() => router.push('/recommend/userinput', '/recommend')}
+            onClick={() => router.push('/recommend/userinput')}
             className='w-full mb-10 text-white rounded-lg h-14 bg-main'
           >
             시작하기

--- a/src/pages/recommend/complete.tsx
+++ b/src/pages/recommend/complete.tsx
@@ -2,11 +2,11 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import React from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { getBookDataByTitle } from '@/api/book';
 import { postBookshelfApi } from '@/api/bookshelf';
+import Header from '@/components/common/Header';
 import { isAuthorizedSelector } from '@/recoil/auth';
 import { isRendedOnboardingAtom } from '@/recoil/onboarding';
 import { RecommendBookResult } from '@/recoil/recommend';
@@ -17,7 +17,6 @@ const RecommendCompletePage = () => {
   const { mutate: postMyBookshelf } = useMutation(postBookshelfApi);
   const isAuthorized = useRecoilValue(isAuthorizedSelector);
   const setIsRendedOnboarding = useSetRecoilState(isRendedOnboardingAtom);
-
   const {
     data: recommendBookData,
     isError,
@@ -27,23 +26,20 @@ const RecommendCompletePage = () => {
     cacheTime: 0,
   });
 
-  if (isLoading) return <></>;
-
-  if (isError || !recommendBookData.documents.length)
+  if (isError || !bookTitle || !recommendBookData?.documents.length)
     return (
       <div className='flex flex-col items-center justify-center h-full bg-[#FFFEF8] text-textBlack'>
         <h3 className='font-medium text-clamp2xl'>책을 찾지 못했어요!</h3>
         <p>다시 시도해주세요😥</p>
         <button
           className='p-2 mt-4 text-white rounded bg-main'
-          onClick={() => {
-            router.back();
-          }}
+          onClick={() => router.push('/recommend/userinput')}
         >
           돌아가기
         </button>
       </div>
     );
+  if (isLoading) return <></>;
 
   const { authors, isbn, thumbnail, title } = recommendBookData.documents[0];
 
@@ -115,7 +111,8 @@ const RecommendCompletePage = () => {
 
   return (
     <div className='h-full bg-[url(/images/bookRecommend/background3.svg)] bg-no-repeat bg-cover bg-center'>
-      <div className='flex items-center justify-center h-[30.125rem]'>
+      <Header />
+      <div className='flex items-center justify-center h-[26.375rem]'>
         <Image
           src={thumbnail}
           width={187}

--- a/src/pages/recommend/userinput.tsx
+++ b/src/pages/recommend/userinput.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import React, { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useSetRecoilState } from 'recoil';
 
 import { postGPTRecommendBook } from '@/api/recommend';
@@ -18,6 +18,7 @@ const RecommendInputPage = () => {
     mutate: postGPTRecommend,
     isLoading,
     isError,
+    isSuccess,
   } = useMutation(postGPTRecommendBook);
 
   const handleChangeRequestInput = (e: ChangeEvent<HTMLTextAreaElement>) => {
@@ -35,7 +36,7 @@ const RecommendInputPage = () => {
           title: data.title,
           reason: data.reason,
         });
-        router.push('/recommend/complete', '/');
+        router.push('/recommend/complete', '/recommend');
       },
     });
   };
@@ -44,6 +45,7 @@ const RecommendInputPage = () => {
     return <RecommendLoading />;
   }
   if (isError) return <></>;
+  if (isSuccess) return null;
 
   return (
     <div className='flex flex-col items-center justify-between h-full p-5 bg-[url(/images/bookRecommend/background2.svg)] bg-no-repeat bg-cover bg-center'>


### PR DESCRIPTION
## 📌 이슈 번호

- close #457  <!-- 링크 달기 -->

## 👩‍💻 작업 내용

<!-- 자세히 쓰기 - 이미지가 필요한 경우 첨부하기, 영상도 ok -->
- 책 추천 실패로 돌아가기 시 `recommend/userinput` 페이지로 이동할 수 있도록 변경
- `독서메이트 00 입니다` -> `독서메이트입니다` 로 변경 
- complete 페이지에 헤더 추가
  - 로그인 시 담기와 상세보기가 가능한데 상세보기를 한 경우나 아무것도 하지 않은 경우다른 페이지로 이동할 수 있는 방법이 없어 뒤로가기 버튼을 추가하였습니다.
  - 상세보기를 한 경우에도 bottom nav 가 없고 상세 페이지에서 뒤로가기 하면 complete 페이지로 돌아와서 다른 페이지로 이동이 불편하더라구요!
- 간혹 api에서 response 데이터가 온전한 객체로 넘어오지 않을 때가 있습니다. 그 때 bookTitle이 undefined가 되는데 이때 임시로 찾을 수 없다는 에러 메세지가 뜨도록 해두었습니다! 온전한 객체가 넘어오게 되면 제거할 예정입니다~
## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
